### PR TITLE
Cell width issue

### DIFF
--- a/px-datetime-entry-cell.html
+++ b/px-datetime-entry-cell.html
@@ -207,8 +207,7 @@ Datetime input element. Includes iron-ally-keys-behavior to limit keystrokes to 
           c = document.createElement('canvas'),
           ctx=c.getContext('2d'),
           length;
-
-      //TODO: fallback if not style
+          
       if(fontSize === "0px" || fontSize === "0"){
         console.log("fontSize is 0px");
         setTimeout(function(){

--- a/px-datetime-entry-cell.html
+++ b/px-datetime-entry-cell.html
@@ -208,6 +208,14 @@ Datetime input element. Includes iron-ally-keys-behavior to limit keystrokes to 
           ctx=c.getContext('2d'),
           length;
 
+      //TODO: fallback if not style
+      if(fontSize === "0px" || fontSize === "0"){
+        console.log("fontSize is 0px");
+        setTimeout(function(){
+          this._sizeInputs();
+        }.bind(this),50);
+        return;
+      }
       ctx.font = fontSize + " " + fontFamily;
       length = ctx.measureText(this.dtWorkingCopy).width;
       length = Math.ceil(length);


### PR DESCRIPTION
This is a fix for a bug filed in the predix forms: 
http://forum.predix.io/questions/14439/seeing-issue-in-px-rangepicker.html#answer-14878

When the rangepicker was loaded too early this problem occurred. 
![screen shot 2016-11-16 at 4 10 53 pm](https://cloud.githubusercontent.com/assets/14931112/20371099/49f0b23a-ac17-11e6-95b9-2f7f6b6ad939.png)
![screen shot 2016-11-16 at 4 10 32 pm](https://cloud.githubusercontent.com/assets/14931112/20371103/4c210bcc-ac17-11e6-981d-3f3a2907679d.png)

The cause of the problem was that entry-cell was returning a fontSize of 0px. We have added a check to see if the fontSize is 0px and if so we wait 50 milliseconds and run the function again to give it enough time to load. 