### PR TITLE
add min/max to datetime components

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -9,6 +9,7 @@
 <link rel="import" href="../../px-demo/px-demo-props.html" />
 <link rel="import" href="../../px-demo/px-demo-interactive.html" />
 <link rel="import" href="../../px-demo/px-demo-component-snippet.html" />
+<link rel="import" href="../../px-demo/px-demo-code-editor.html" />
 
 <!-- Imports for this component -->
 <link rel="import" href="../../px-demo/css/px-demo-styles.html" />
@@ -33,6 +34,8 @@
       <!-- Props -->
       <px-demo-props props="{{props}}" config="[[chosenConfig]]"></px-demo-props>
 
+      <px-demo-code-editor props="{{props}}" config="[[chosenConfig]]"></px-demo-code-editor>
+
       <!-- Component ---------------------------------------------------------->
       <px-demo-component>
         <p class=u-mb0>Event fired: <strong>px-datetime-submitted</strong></p>
@@ -47,7 +50,8 @@
             show-time-zone="{{props.showTimeZone.value}}"
             time-zone="{{props.timeZone.value}}"
             moment-format="{{props.momentFormat.value}}"
-            >
+            min="{{props.min.value}}"
+            max="{{props.max.value}}">
         </px-datetime-entry>
       </px-demo-component>
       <!-- END Component ------------------------------------------------------>
@@ -153,6 +157,18 @@
         defaultValue: 'UTC',
         inputType: 'text',
         inputPlaceholder: 'UTC'
+      },
+
+      min: {
+        type: Object,
+        defaultValue: Px.moment().subtract(7, 'day'),
+        inputType: 'code:JSON'
+      },
+
+      max: {
+        type: Object,
+        defaultValue: Px.moment().add(7, 'day'),
+        inputType: 'code:JSON'
       }
 
     }

--- a/px-datetime-entry.html
+++ b/px-datetime-entry.html
@@ -147,7 +147,8 @@ Custom property | Description
       },
       /**
        * Determines how to display the timezone:
-       * - 'dropdown': shows the timezone as a dropdown which the user can use to select a different timezone. Only contains a subset of all timezones
+       * - 'dropdown': shows the timezone as a dropdown which the user can use to select a different timezone. Only contains a subset of all timezones.
+       * **NOTE: this collection of timezones uses the POSIX convention for timezone offset, meaning that positive values correspond to timezones WEST of GMT and negative values correspond to timezones EAST of GMT.**
        * - 'extendedDropdown': shows the timezone as a dropdown which the user can use to select a different timezone. Contains all existing timezones (588)
        * - 'text': shows the timezone as text, non editable
        * - 'abbreviatedText': shows the timezone as an abbreviated text, non editable (e.g. UTC, PST, EST, etc)

--- a/px-datetime-shared-behavior.html
+++ b/px-datetime-shared-behavior.html
@@ -26,6 +26,24 @@ PxDatetimeBehavior.blockDates = {
     blockPastDates: {
       type: Boolean,
       value: false
+    },
+    /**
+     * The minimum / earliest allowed date, as a Moment object (dates before this will be disabled and unclickable).
+     */
+    min: {
+      type: Object,
+      value: function() {
+        return {};
+      }
+    },
+    /**
+     * The maximum / latest allowed date, as a Moment object (dates after this will be disabled and unclickable).
+     */
+    max: {
+      type: Object,
+      value: function() {
+        return {};
+      }
     }
   }
 }

--- a/test/px-datetime-entry-tests.js
+++ b/test/px-datetime-entry-tests.js
@@ -400,7 +400,7 @@ function runCustomTests() {
 
           assert.isFalse(date1.isValid);
 
-          //reset it to somwhting valid
+          //reset it to something valid
           fireKeyboardEvent(cells[1], '1');
           fireKeyboardEvent(cells[1], 'Enter');
 
@@ -415,6 +415,28 @@ function runCustomTests() {
       //wait for validation to kick in
       setTimeout(function() {
         assert.isFalse(date2.isValid);
+        done();
+      }, 200);
+    });
+
+    test('block dates before min', function(done) {
+      date1.set('min', date1.momentObj.clone().subtract(1, 'day'));
+      date1.momentObj = date1.momentObj.clone().subtract(1, 'month');
+
+      //wait for validation to kick in
+      setTimeout(function() {
+        assert.isFalse(date1.isValid);
+        done();
+      }, 200);
+    });
+
+    test('block dates after max', function(done) {
+      date1.set('max', date1.momentObj.clone().add(1, 'day'));
+      date1.momentObj = date1.momentObj.clone().add(1, 'month');
+
+      //wait for validation to kick in
+      setTimeout(function() {
+        assert.isFalse(date1.isValid);
         done();
       }, 200);
     });

--- a/validate.html
+++ b/validate.html
@@ -105,14 +105,20 @@ var validate = [Polymer.AppLocalizeBehavior, {
     inputStr = inputStr.split('\xa0').join(' ');
     var inputMoment = Px.moment.tz(inputStr, this.momentFormat, this.timeZone),
         notAllowedInFuture = this.dateOrTime.toLowerCase() === 'date' &&
-                              this.blockFutureDates &&
-                              inputMoment.isAfter(Px.moment.tz(Px.moment(), this.timeZone), 'day'),
+                             this.blockFutureDates &&
+                             inputMoment.isAfter(Px.moment.tz(Px.moment(), this.timeZone)),
+        notAllowedAfterMax = this.dateOrTime.toLowerCase() === 'date' &&
+                             Object.keys(this.max).length > 0 &&
+                             inputMoment.isAfter(this.max),
         notAllowedInPast = this.dateOrTime.toLowerCase() === 'date' &&
-                              this.blockPastDates &&
-                              inputMoment.isBefore(Px.moment.tz(Px.moment(), this.timeZone), 'day');
+                           this.blockPastDates &&
+                           inputMoment.isBefore(Px.moment.tz(Px.moment(), this.timeZone)),
+        notAllowedBeforeMin = this.dateOrTime.toLowerCase() === 'date' &&
+                              Object.keys(this.min).length > 0 &&
+                              inputMoment.isBefore(this.min);
 
     // if the component datetime string is a valid datetime
-    if((inputMoment.isValid() && !notAllowedInFuture && !notAllowedInPast)) {
+    if((inputMoment.isValid() && !notAllowedInFuture && !notAllowedInPast && !notAllowedAfterMax && !notAllowedBeforeMin)) {
       // turn off input box error outline
       this.toggleClass('validation-error', false, this.$.wrapper);
       /*


### PR DESCRIPTION
Added the ability to set a minimum and maximum moment object. You can test locally on the demo page, or use bower link to test it with the other datetime components. I have branches started for a few of them, and can proceed rolling this out if you think it looks ok.