### PR TITLE
Add namespace to behaviors, breaking change

### DIFF
--- a/px-datetime-behavior.html
+++ b/px-datetime-behavior.html
@@ -1,114 +1,108 @@
-<link rel="import" href="px-datetime-shared-behavior.html" />
+<link rel="import" href="px-datetime-shared-behavior.html"/>
 
 <script>
+(function() {
+  var PxDatetimeBehavior = window.PxDatetimeBehavior = (window.PxDatetimeBehavior || {});
 
-/**
-  ```pxDatetimeBehavior```
+  /**
+   * For all `px-{datetime}-{picker}` components.
+   * Dependencies: momentjs
+   *
+   * @polymerBehavior PxDatetimeBehavior.SingleDate
+   */
+  PxDatetimeBehavior.SingleDate = [{
+    properties: {
+      /**
+       * Moment value with the date or time to display.  Will be parsed according to the moment format. (See momentFormat property.)
+       */
+      momentObj: {
+        type: Object,
+        notify: true,
+        value: function() {
+          return null;
+        }
+      }
+    },
 
-  This behavior is for all ```px-{datetime}-{picker}``` components.
+    observers: ['_localeChanged(language)',
+                '_timeZoneChanged(timeZone)'],
 
-  Dependencies: momentjs
-
-  @polymerBehavior pxDatetimeBehavior
-*/
-var pxDatetimeBehavior = [{
-
-  properties: {
     /**
-     * Moment value with the date or time to display.  Will be parsed according to the moment format. (See momentFormat property.)
+     * Make sure the moment obj pick up the possibly new moment locale
      */
-    momentObj: {
-      type: Object,
-      notify: true,
-      value: function() {
-        return null;
+    _localeChanged: function() {
+      if(this.language !== undefined && this.momentObj) {
+        this.set('momentObj', this.momentObj.locale(Px.moment.locale()));
+      }
+    },
+    /**
+     * Makes sure the moment object reflects the right timezone.
+     */
+    _timeZoneChanged: function() {
+      if(this.timeZone !== undefined && this.momentObj) {
+        var newMom = this.momentObj.clone().tz(this.timeZone);
+        this.set('momentObj', newMom);
       }
     }
-  },
-
-  observers: ['_localeChanged(language)',
-              '_timeZoneChanged(timeZone)'],
+  }, PxDatetimeBehavior.Shared];
 
   /**
-   * Make sure the moment obj pick up the possibly new moment locale
+   * Adds a temp moment object that can be applied or used to rollback
+   * Dependencies: momentjs
+   *
+   * @polymerBehavior PxDatetimeBehavior.TempMoment
    */
-  _localeChanged: function() {
-    if(this.language !== undefined && this.momentObj) {
-      this.set('momentObj', this.momentObj.locale(Px.moment.locale()));
-    }
-  },
-  /**
-   * Makes sure the moment object reflects the right timezone.
-   */
-  _timeZoneChanged: function() {
-    if(this.timeZone !== undefined && this.momentObj) {
-      var newMom = this.momentObj.clone().tz(this.timeZone);
-      this.set('momentObj', newMom);
-    }
-  }
-}, pxDatetimeSharedBehavior];
+  PxDatetimeBehavior.TempMoment = [{
+    properties: {
+      /**
+       * temporary moment object used for validation and display. This
+       * object should be used by subcomponents when we want to "try"
+       * a value and see the result of validation AND/OR give us the
+       * ability to rollback (cancel) or apply
+       */
+      _tempMomentObj: {
+        type: Object,
+        notify: true
+      }
+    },
 
-/**
-  ```pxDatetimeBehavior```
+    observers: ['_localeChangedTemp(language)',
+                '_timeZoneChangedTemp(timeZone)',
+                //momentObj is the source of truth and should always
+                //trump temp if changed
+                '_rollbackTempMoment(momentObj)'],
 
-  This behavior adds a temp moment object that can be applied or used to rollback
-
-  Dependencies: momentjs
-
-  @polymerBehavior pxDatetimeBehavior
-*/
-var pxDatetimeTempMomentBehavior = [{
-
-  properties: {
     /**
-     * temporary moment object used for validation and display. This
-     * object should be used by subcomponents when we want to "try"
-     * a value and see the result of validation AND/OR give us the
-     * ability to rollback (cancel) or apply
+     * Applies value of temp moment to public momentObj
      */
-    _tempMomentObj: {
-      type: Object,
-      notify: true
+    _applyTempMoment: function() {
+      if(this.momentObj === null || this._tempMomentObj === null || this.momentObj.toISOString() !== this._tempMomentObj.toISOString()) {
+        this.set('momentObj', this._tempMomentObj);
+      }
+    },
+    /**
+     * Rollback value of temp moment to use public momentObj
+     */
+     _rollbackTempMoment: function() {
+      this.set('_tempMomentObj', this.momentObj);
+    },
+    /**
+     * Make sure the moment obj pick up the possibly new moment locale
+     */
+     _localeChangedTemp: function() {
+      if(this.language !== undefined && this.momentObj) {
+        this.set('_tempMomentObj', this._tempMomentObj.locale(Px.moment.locale()));
+      }
+    },
+    /**
+     * Makes sure the moment object reflects the right timezone.
+     */
+     _timeZoneChangedTemp: function() {
+      if(this.timeZone !== undefined && this.momentObj) {
+        var newMom = this._tempMomentObj.clone().tz(this.timeZone);
+        this.set('_tempMomentObj', newMom);
+      }
     }
-  },
-
-  observers: ['_localeChangedTemp(language)',
-              '_timeZoneChangedTemp(timeZone)',
-              //momentObj is the source of truth and should always
-              //trump temp if changed
-              '_rollbackTempMoment(momentObj)'],
-
-  /**
-   * Applies value of temp moment to public momentObj
-   */
-  _applyTempMoment: function() {
-    if(this.momentObj === null || this._tempMomentObj === null || this.momentObj.toISOString() !== this._tempMomentObj.toISOString()) {
-      this.set('momentObj', this._tempMomentObj);
-    }
-  },
-  /**
-   * Rollback value of temp moment to use public momentObj
-   */
-   _rollbackTempMoment: function() {
-    this.set('_tempMomentObj', this.momentObj);
-  },
-  /**
-   * Make sure the moment obj pick up the possibly new moment locale
-   */
-   _localeChangedTemp: function() {
-    if(this.language !== undefined && this.momentObj) {
-      this.set('_tempMomentObj', this._tempMomentObj.locale(Px.moment.locale()));
-    }
-  },
-  /**
-   * Makes sure the moment object reflects the right timezone.
-   */
-   _timeZoneChangedTemp: function() {
-    if(this.timeZone !== undefined && this.momentObj) {
-      var newMom = this._tempMomentObj.clone().tz(this.timeZone);
-      this.set('_tempMomentObj', newMom);
-    }
-  }
-}, pxDatetimeBehavior];
-
+  }, PxDatetimeBehavior.SingleDate];
+})();
 </script>

--- a/px-datetime-button-behavior.html
+++ b/px-datetime-button-behavior.html
@@ -1,28 +1,25 @@
-<link rel="import" href="../px-moment-imports/px-moment-imports.html" />
-<link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
+<link rel="import" href="../px-moment-imports/px-moment-imports.html"/>
+<link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html"/>
 
 <script>
-/**
+(function() {
+  var PxDatetimeBehavior = window.PxDatetimeBehavior = (window.PxDatetimeBehavior || {});
 
-  ```pxDatetimeButtonBehavior```
-
-  This behavior is for ```px-datetime``` components that can have apply/cancel buttons.
-
-  @polymerBehavior pxDatetimeButtonBehavior
-
-*/
-
-var pxDatetimeButtonBehavior = [{
-
-  properties: {
-    /**
-     * Whether to show Apply and Cancel buttons in the components
-     */
-    showButtons: {
-      type: Boolean,
-      value: false
+  /**
+   * For components that can have apply/cancel buttons
+   *
+   * @polymerBehavior PxDatetimeBehavior.Buttons
+   */
+  PxDatetimeBehavior.Buttons = [{
+    properties: {
+      /**
+       * Whether to show Apply and Cancel buttons in the components
+       */
+      showButtons: {
+        type: Boolean,
+        value: false
+      }
     }
-  }
-}, Polymer.IronA11yKeysBehavior];
-
+  }, Polymer.IronA11yKeysBehavior];
+})();
 </script>

--- a/px-datetime-buttons.html
+++ b/px-datetime-buttons.html
@@ -40,7 +40,7 @@ Date time button component.
     is: 'px-datetime-buttons',
 
     behaviors: [
-      validate,
+      PxDatetimeBehavior.Validate,
       Polymer.AppLocalizeBehavior
     ],
 

--- a/px-datetime-entry-cell.html
+++ b/px-datetime-entry-cell.html
@@ -53,8 +53,8 @@ Datetime input element. Includes iron-ally-keys-behavior to limit keystrokes to 
     is: 'px-datetime-entry-cell',
 
     behaviors: [
-      pxDatetimeBehavior,
-      validate,
+      PxDatetimeBehavior.SingleDate,
+      PxDatetimeBehavior.Validate,
       Polymer.IronA11yKeysBehavior
     ],
 

--- a/px-datetime-entry.html
+++ b/px-datetime-entry.html
@@ -98,8 +98,8 @@ Custom property | Description
     is: 'px-datetime-entry',
 
     behaviors: [
-      pxDatetimeBehavior,
-      validate
+      PxDatetimeBehavior.SingleDate,
+      PxDatetimeBehavior.Validate
     ],
 
     properties: {

--- a/px-datetime-presets.html
+++ b/px-datetime-presets.html
@@ -37,7 +37,8 @@ The list of preset ranges in the rangepicker modal.
     is: 'px-datetime-presets',
 
     behaviors: [
-      Polymer.AppLocalizeBehavior],
+      Polymer.AppLocalizeBehavior
+    ],
 
     properties: {
 

--- a/px-datetime-range-behavior.html
+++ b/px-datetime-range-behavior.html
@@ -1,228 +1,217 @@
-<link rel="import" href="px-datetime-shared-behavior.html" />
+<link rel="import" href="px-datetime-shared-behavior.html"/>
 
 <script>
-var PxDatetimeBehavior = PxDatetimeBehavior || {};
+(function() {
+  var PxDatetimeBehavior = window.PxDatetimeBehavior = (window.PxDatetimeBehavior || {});
 
-/*
-    PxDatetimeBehavior.rangeMoments
-
-    Description:
-    Behavior providing the fromMoment and toMoment properties
-    @polymerBehavior PxDatetimeBehavior.rangeMoments
-*/
-PxDatetimeBehavior.rangeMoments = {
-  properties: {
-    /**
-     * Moment object start date & time
-     */
-    fromMoment: {
-      type: Object,
-      notify: true,
-      value: function() {
-        return null;
-      }
-    },
-    /**
-     * Moment object end date & time
-     */
-    toMoment: {
-      type: Object,
-      notify: true,
-      value: function() {
-        return null;
-      }
-    }
-  }
-}
-
-/**
-  ```pxDatetimeRangeBehavior```
-
-  This behavior is for all ```px-{datetime}-range-{picker}``` components.
-
-  Dependencies: momentjs
-
-  @polymerBehavior pxDatetimeRangeBehavior
-*/
-var pxDatetimeRangeBehavior = [{
-
-  properties: {
-
-    /**
-     * (optional:  'px-{datetime}-range-panel')
-     *
-     * The preset date/time ranges to be displayed.
-     *
-     *```
-     *   [
-     *    {
-     *      "displayText": "Last 5 Minutes",
-     *      "startDateTime": "2013-02-04T22:44:30.652Z",
-     *      "endDateTime": "2013-02-04T22:49:30.652Z"
-     *    },
-     *    {
-     *      "displayText": "Last 12 Hours",
-     *      "startDateTime": function() {return moment().subtract(1, 'days').toISOString();},
-     *      "endDateTime": function() {return moment().startOf('day').toISOString();}
-     *    }
-     *   ]
-     * ```
-     *
-     * @default no presetRanges
-     */
-    presetRanges: {
-     type: Object, //may be useless
-    }
-
-  },
-  observers: [
-    '_localeChanged(language)',
-    '_timeZoneChanged(timeZone)'
-  ],
   /**
-   * make sure the moment obj picks up the possibly new moment locale
-   */
-  _localeChanged: function() {
-    if(this.language !== undefined) {
-      if(this.fromMoment) {
-        this.set('fromMoment', this.fromMoment.locale(Px.moment.locale()));
-      }
-      if(this.toMoment) {
-        this.set('toMoment', this.toMoment.locale(Px.moment.locale()));
-      }
-    }
-  },
-  /**
-   * makes sure the moment objects reflect the timezone
-   */
-  _timeZoneChanged: function() {
-    if(this.timeZone !== undefined) {
-      if(this.fromMoment) {
-        var newMom = this.fromMoment.clone().tz(this.timeZone);
-        this.set('fromMoment', newMom);
-      }
-      if(this.toMoment) {
-        newMom = this.toMoment.clone().tz(this.timeZone);
-        this.set('toMoment', newMom);
-      }
-    }
-  },
-  /**
-   * Validation for the range. Makes sure the ranges are in chronological order
+   * Provides the fromMoment and toMoment properties
    *
-   * @return {Boolean} true if chronological order, false otherwise
+   * @polymerBehavior PxDatetimeBehavior.RangeMoments
    */
-  _validateRangeOrder: function(fromMoment, toMoment) {
-    // if the from date is before the to date, everything is ok
-    if(fromMoment === null && toMoment === null) {
-      return true;
-    } if(fromMoment && toMoment) {
-      return fromMoment.isBefore(toMoment);
-    } else {
-      return false;
+  PxDatetimeBehavior.RangeMoments = {
+    properties: {
+      /**
+       * Moment object start date & time
+       */
+      fromMoment: {
+        type: Object,
+        notify: true,
+        value: function() {
+          return null;
+        }
+      },
+      /**
+       * Moment object end date & time
+       */
+      toMoment: {
+        type: Object,
+        notify: true,
+        value: function() {
+          return null;
+        }
+      }
     }
-  },
-}, pxDatetimeSharedBehavior, PxDatetimeBehavior.rangeMoments];
+  };
 
-/**
-  ```pxDatetimeBehavior```
+  /**
+   * For all `px-{datetime}-range-{picker}` components
+   *
+   * @polymerBehavior PxDatetimeBehavior.Range
+   */
+  PxDatetimeBehavior.Range = [{
+    properties: {
 
-  This behavior adds a temp moment object that can be applied or used to rollback
-
-  Dependencies: momentjs
-
-  @polymerBehavior pxDatetimeBehavior
-*/
-var pxDatetimeTempRangeBehavior = [{
-
-  properties: {
+      /**
+       * (optional:  'px-{datetime}-range-panel')
+       *
+       * The preset date/time ranges to be displayed.
+       *
+       *```
+       *   [
+       *    {
+       *      "displayText": "Last 5 Minutes",
+       *      "startDateTime": "2013-02-04T22:44:30.652Z",
+       *      "endDateTime": "2013-02-04T22:49:30.652Z"
+       *    },
+       *    {
+       *      "displayText": "Last 12 Hours",
+       *      "startDateTime": function() {return moment().subtract(1, 'days').toISOString();},
+       *      "endDateTime": function() {return moment().startOf('day').toISOString();}
+       *    }
+       *   ]
+       * ```
+       *
+       * @default no presetRanges
+       */
+      presetRanges: {
+       type: Object, //may be useless
+      }
+    },
+    observers: [
+      '_localeChanged(language)',
+      '_timeZoneChanged(timeZone)'
+    ],
     /**
-     * Temporary from moment object used for validation and displaying.
-     * This object should be used by subcomponents when we want to "try"
-     * a value and see the result of validation AND/OR give us the ability
-     * to rollback (cancel) or apply
+     * make sure the moment obj picks up the possibly new moment locale
      */
-    _tempFromMomentObj: {
-      type: Object,
-      notify: true
+    _localeChanged: function() {
+      if(this.language !== undefined) {
+        if(this.fromMoment) {
+          this.set('fromMoment', this.fromMoment.locale(Px.moment.locale()));
+        }
+        if(this.toMoment) {
+          this.set('toMoment', this.toMoment.locale(Px.moment.locale()));
+        }
+      }
     },
     /**
-     * Temporary to moment object used for validation and displaying.
-     * This object should be used by subcomponents when we want to "try"
-     * a value and see the result of validation AND/OR give us the ability
-     * to rollback (cancel) or apply
+     * makes sure the moment objects reflect the timezone
      */
-    _tempToMomentObj: {
-      type: Object,
-      notify: true
-    }
-  },
-
-  observers: ['_localeChangedTemp(language)',
-              '_timeZoneChangedTemp(timeZone)',
-              //momentObj is the source of truth and should always
-              //trump temp if changed
-              '_rollbackTempFromMoment(fromMoment)',
-              '_rollbackTempToMoment(toMoment)'],
-
-  /**
-   * Applies value of temp moment to public momentObj
-   */
-  _applyTempRangeMoment: function() {
-
-    var changed = false;
-    if(this.fromMoment === null || this._tempFromMomentObj === null || this.fromMoment.toISOString() !== this._tempFromMomentObj.toISOString()) {
-      this.set('fromMoment', this._tempFromMomentObj);
-      changed = true;
-    }
-
-    if(this.toMoment === null || this._tempToMomentObj === null || this.toMoment.toISOString() !== this._tempToMomentObj.toISOString()) {
-      this.set('toMoment', this._tempToMomentObj);
-      changed = true;
-    }
-
-    return changed;
-  },
-  /**
-   * Rollback value of temp fromMoment to use public momentObj
-   */
-   _rollbackTempFromMoment: function(fromMoment) {
-    this.set('_tempFromMomentObj', this.fromMoment);
-  },
-  /**
-   * Rollback value of temp toMoment to use public momentObj
-   */
-   _rollbackTempToMoment: function(toMoment) {
-    this.set('_tempToMomentObj', this.toMoment);
-  },
-  /**
-   * make sure the moment obj pick up the possibly new moment locale
-   */
-   _localeChangedTemp: function() {
-    if(this.language !== undefined) {
-      if(this.fromMoment) {
-        this.set('_tempFromMomentObj', this._tempFromMomentObj.locale(Px.moment.locale()));
+    _timeZoneChanged: function() {
+      if(this.timeZone !== undefined) {
+        if(this.fromMoment) {
+          var newMom = this.fromMoment.clone().tz(this.timeZone);
+          this.set('fromMoment', newMom);
+        }
+        if(this.toMoment) {
+          newMom = this.toMoment.clone().tz(this.timeZone);
+          this.set('toMoment', newMom);
+        }
       }
-      if(this.toMoment) {
-        this.set('_tempToMomentObj', this._tempToMomentObj.locale(Px.moment.locale()));
+    },
+    /**
+     * Validation for the range. Makes sure the ranges are in chronological order
+     *
+     * @return {Boolean} true if chronological order, false otherwise
+     */
+    _validateRangeOrder: function(fromMoment, toMoment) {
+      // if the from date is before the to date, everything is ok
+      if(fromMoment === null && toMoment === null) {
+        return true;
+      } if(fromMoment && toMoment) {
+        return fromMoment.isBefore(toMoment);
+      } else {
+        return false;
       }
-    }
-  },
-  /**
-   * makes sure the moment objects reflect the timezone
-   */
-   _timeZoneChangedTemp: function() {
-    if(this.timeZone !== undefined) {
-      if(this.fromMoment) {
-        var newMom = this._tempFromMomentObj.clone().tz(this.timeZone);
-        this.set('_tempFromMomentObj', newMom);
-      }
-      if(this.toMoment) {
-        newMom = this._tempToMomentObj.clone().tz(this.timeZone);
-        this.set('_tempToMomentObj', newMom);
-      }
-    }
-  },
-}, pxDatetimeRangeBehavior];
+    },
+  }, PxDatetimeBehavior.Shared, PxDatetimeBehavior.RangeMoments];
 
+  /**
+   * Adds a temp moment object that can be applied or used to rollback
+   *
+   * @polymerBehavior PxDatetimeBehavior.TempRange
+   */
+  PxDatetimeBehavior.TempRange = [{
+
+    properties: {
+      /**
+       * Temporary from moment object used for validation and displaying.
+       * This object should be used by subcomponents when we want to "try"
+       * a value and see the result of validation AND/OR give us the ability
+       * to rollback (cancel) or apply
+       */
+      _tempFromMomentObj: {
+        type: Object,
+        notify: true
+      },
+      /**
+       * Temporary to moment object used for validation and displaying.
+       * This object should be used by subcomponents when we want to "try"
+       * a value and see the result of validation AND/OR give us the ability
+       * to rollback (cancel) or apply
+       */
+      _tempToMomentObj: {
+        type: Object,
+        notify: true
+      }
+    },
+
+    observers: ['_localeChangedTemp(language)',
+                '_timeZoneChangedTemp(timeZone)',
+                //momentObj is the source of truth and should always
+                //trump temp if changed
+                '_rollbackTempFromMoment(fromMoment)',
+                '_rollbackTempToMoment(toMoment)'],
+
+    /**
+     * Applies value of temp moment to public momentObj
+     */
+    _applyTempRangeMoment: function() {
+
+      var changed = false;
+      if(this.fromMoment === null || this._tempFromMomentObj === null || this.fromMoment.toISOString() !== this._tempFromMomentObj.toISOString()) {
+        this.set('fromMoment', this._tempFromMomentObj);
+        changed = true;
+      }
+
+      if(this.toMoment === null || this._tempToMomentObj === null || this.toMoment.toISOString() !== this._tempToMomentObj.toISOString()) {
+        this.set('toMoment', this._tempToMomentObj);
+        changed = true;
+      }
+
+      return changed;
+    },
+    /**
+     * Rollback value of temp fromMoment to use public momentObj
+     */
+     _rollbackTempFromMoment: function(fromMoment) {
+      this.set('_tempFromMomentObj', this.fromMoment);
+    },
+    /**
+     * Rollback value of temp toMoment to use public momentObj
+     */
+     _rollbackTempToMoment: function(toMoment) {
+      this.set('_tempToMomentObj', this.toMoment);
+    },
+    /**
+     * make sure the moment obj pick up the possibly new moment locale
+     */
+     _localeChangedTemp: function() {
+      if(this.language !== undefined) {
+        if(this.fromMoment) {
+          this.set('_tempFromMomentObj', this._tempFromMomentObj.locale(Px.moment.locale()));
+        }
+        if(this.toMoment) {
+          this.set('_tempToMomentObj', this._tempToMomentObj.locale(Px.moment.locale()));
+        }
+      }
+    },
+    /**
+     * makes sure the moment objects reflect the timezone
+     */
+     _timeZoneChangedTemp: function() {
+      if(this.timeZone !== undefined) {
+        if(this.fromMoment) {
+          var newMom = this._tempFromMomentObj.clone().tz(this.timeZone);
+          this.set('_tempFromMomentObj', newMom);
+        }
+        if(this.toMoment) {
+          newMom = this._tempToMomentObj.clone().tz(this.timeZone);
+          this.set('_tempToMomentObj', newMom);
+        }
+      }
+    },
+  }, PxDatetimeBehavior.Range];
+})();
 </script>

--- a/px-datetime-shared-behavior.html
+++ b/px-datetime-shared-behavior.html
@@ -1,142 +1,135 @@
-<link rel="import" href="../px-moment-imports/px-moment-imports.html" />
-<link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
-<link rel="import" href="../app-localize-behavior/app-localize-behavior.html" />
+<link rel="import" href="../px-moment-imports/px-moment-imports.html"/>
+<link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html"/>
+<link rel="import" href="../app-localize-behavior/app-localize-behavior.html"/>
 
 <script>
-var PxDatetimeBehavior = PxDatetimeBehavior || {};
-/*
-    PxDatetimeBehavior.blockDates
+(function() {
+  var PxDatetimeBehavior = window.PxDatetimeBehavior = (window.PxDatetimeBehavior || {});
 
-    Description:
-    Behavior providing the blockPastDates and blockFutureDates properties
-    @polymerBehavior PxDatetimeBehavior.blockDates
-*/
-PxDatetimeBehavior.blockDates = {
-  properties: {
-    /**
-     * Set this attribute when you do not want to allow future dates to be selected (future dates will be disabled and unclickable).
-     */
-    blockFutureDates: {
-      type: Boolean,
-      value: false
-    },
-    /**
-     * Set this attribute when you do not want to allow past dates to be selected (past dates will be disabled and unclickable).
-     */
-    blockPastDates: {
-      type: Boolean,
-      value: false
-    },
-  }
-}
-
-/**
-  ```pxDatetimeSharedBehavior```
-
-  This behavior is for all ```px-datetime``` components.
-
-  Dependencies: momentjs
-
-  @polymerBehavior pxDatetimeSharedBehavior
-*/
-
-var pxDatetimeSharedBehavior = [{
-
-  properties: {
-
-    /**
-     * Moment-timezone string for using a specific timezone. See
-     * http://momentjs.com/timezone/docs/#/data-loading/getting-zone-names/.
-     *
-     * If not provided, tries to guess the current local timezone.
-     *
-     * @default Px.moment.tz.guess();
-     */
-    timeZone: {
-      type: String,
-      notify: true,
-      value: function() {
-        return Px.moment.tz.guess();
-      }
-     },
-     /**
-      * set a default for localizing
-      */
-     language: {
-       type: String,
-       value: 'en'
-     },
-     /**
-      * Use the key for localization if value for  language is missing. Should
-      * always be true for  our components
-      */
-     useKeyIfMissing: {
-       type: Boolean,
-       value: true
-     },
-     /**
-     * The minimum / earliest allowed date, as a a Moment object or an ISO 8601 String (dates before this will be disabled and unclickable).
-     */
-    minDate: {
-      type: Object,
-      observer: '_minDateChanged'
-    },
-    /**
-     * The maximum / latest allowed date, as a a Moment object or an ISO 8601 String (dates after this will be disabled and unclickable).
-     */
-    maxDate: {
-      type: Object,
-      observer: '_maxDateChanged'
-    }
-  },
-  observers: [
-    '_updateMinMaxTz(timeZone)'
-  ],
-  _updateMinMaxTz: function() {
-    if(this.timeZone !== undefined) {
-      if(this.minDate && this.minDate.tz) {
-        this.minDate.tz(this.timeZone);
-      }
-      if(this.maxDate && this.maxDate.tz) {
-        this.maxDate.tz(this.timeZone);
-      }
-    }
-  },
-  _minDateChanged: function() {
-    if(typeof this.minDate === 'string') {
-      if(this.timeZone) {
-        this.minDate = Px.moment.tz(this.minDate, this.timeZone);
-      } else {
-        this.minDate = Px.moment(this.minDate);
-      }
-    }
-  },
-  _maxDateChanged: function() {
-    if(typeof this.maxDate === 'string') {
-      if(this.timeZone) {
-        this.maxDate = Px.moment.tz(this.maxDate, this.timeZone);
-      } else {
-        this.maxDate = Px.moment(this.maxDate);
-      }
-    }
-  },
   /**
-   * Copies the time in toPreserve to dest and returns dest.
-   * used in `px-calendar-picker`, `px-datetime-picker`, and `px-datetime-range-panel`
+   * Provides the blockPastDates and blockFutureDates properties
    *
-   * @param {} toPreserve
-   * @param {} dest
+   * @polymerBehavior PxDatetimeBehavior.BlockDates
    */
-  _preserveTime: function(toPreserve, dest) {
-    if(toPreserve && dest) {
-      dest.hours(toPreserve.hours());
-      dest.minutes(toPreserve.minutes());
-      dest.seconds(toPreserve.seconds());
-      dest.milliseconds(toPreserve.milliseconds());
+  PxDatetimeBehavior.BlockDates = {
+    properties: {
+      /**
+       * Set this attribute when you do not want to allow future dates to be selected (future dates will be disabled and unclickable).
+       */
+      blockFutureDates: {
+        type: Boolean,
+        value: false
+      },
+      /**
+       * Set this attribute when you do not want to allow past dates to be selected (past dates will be disabled and unclickable).
+       */
+      blockPastDates: {
+        type: Boolean,
+        value: false
+      }
     }
-    return dest;
-  }
-}, Polymer.IronA11yKeysBehavior, PxDatetimeBehavior.blockDates, Polymer.AppLocalizeBehavior];
+  };
 
-
+  /**
+   * For all `px-datetime` components
+   * Dependencies: momentjs
+   *
+   * @polymerBehavior PxDatetimeBehavior.Shared
+   */
+  PxDatetimeBehavior.Shared = [{
+    properties: {
+      /**
+       * Moment-timezone string for using a specific timezone. See
+       * http://momentjs.com/timezone/docs/#/data-loading/getting-zone-names/.
+       *
+       * If not provided, tries to guess the current local timezone.
+       *
+       * @default Px.moment.tz.guess();
+       */
+      timeZone: {
+        type: String,
+        notify: true,
+        value: function() {
+          return Px.moment.tz.guess();
+        }
+       },
+       /**
+        * set a default for localizing
+        */
+       language: {
+         type: String,
+         value: 'en'
+       },
+       /**
+        * Use the key for localization if value for  language is missing. Should
+        * always be true for  our components
+        */
+       useKeyIfMissing: {
+         type: Boolean,
+         value: true
+       },
+       /**
+       * The minimum / earliest allowed date, as a a Moment object or an ISO 8601 String (dates before this will be disabled and unclickable).
+       */
+      minDate: {
+        type: Object,
+        observer: '_minDateChanged'
+      },
+      /**
+       * The maximum / latest allowed date, as a a Moment object or an ISO 8601 String (dates after this will be disabled and unclickable).
+       */
+      maxDate: {
+        type: Object,
+        observer: '_maxDateChanged'
+      }
+    },
+    observers: [
+      '_updateMinMaxTz(timeZone)'
+    ],
+    _updateMinMaxTz: function() {
+      if(this.timeZone !== undefined) {
+        if(this.minDate && this.minDate.tz) {
+          this.minDate.tz(this.timeZone);
+        }
+        if(this.maxDate && this.maxDate.tz) {
+          this.maxDate.tz(this.timeZone);
+        }
+      }
+    },
+    _minDateChanged: function() {
+      if(typeof this.minDate === 'string') {
+        if(this.timeZone) {
+          this.minDate = Px.moment.tz(this.minDate, this.timeZone);
+        } else {
+          this.minDate = Px.moment(this.minDate);
+        }
+      }
+    },
+    _maxDateChanged: function() {
+      if(typeof this.maxDate === 'string') {
+        if(this.timeZone) {
+          this.maxDate = Px.moment.tz(this.maxDate, this.timeZone);
+        } else {
+          this.maxDate = Px.moment(this.maxDate);
+        }
+      }
+    },
+    /**
+     * Copies the time in toPreserve to dest and returns dest.
+     * used in `px-calendar-picker`, `px-datetime-picker`, and `px-datetime-range-panel`
+     *
+     * @param {} toPreserve
+     * @param {} dest
+     */
+    _preserveTime: function(toPreserve, dest) {
+      if(toPreserve && dest) {
+        dest.hours(toPreserve.hours());
+        dest.minutes(toPreserve.minutes());
+        dest.seconds(toPreserve.seconds());
+        dest.milliseconds(toPreserve.milliseconds());
+      }
+      return dest;
+    }
+  }, Polymer.IronA11yKeysBehavior, PxDatetimeBehavior.BlockDates, Polymer.AppLocalizeBehavior];
+})();
 </script>

--- a/px-datetime-validate.html
+++ b/px-datetime-validate.html
@@ -1,16 +1,16 @@
-<link rel="import" href="../app-localize-behavior/app-localize-behavior.html" />
+<link rel="import" href="../app-localize-behavior/app-localize-behavior.html"/>
+
 <script>
+(function() {
+  var PxDatetimeBehavior = window.PxDatetimeBehavior = (window.PxDatetimeBehavior || {});
+
   /**
-    ```validate```
-
-    A collection of validation scripts for px-datetime components
-
-    Dependencies: momentjs
-
-    @polymerBehavior validate
-  */
-
-  var validate = [Polymer.AppLocalizeBehavior, {
+   * Collection of validation scripts for px-datetime components
+   * Dependencies: momentjs
+   *
+   * @polymerBehavior PxDatetimeBehavior.Validate
+   */
+  PxDatetimeBehavior.Validate = [Polymer.AppLocalizeBehavior, {
     properties: {
       /**
        * Boolean stating if the current component is valid. Gets updated in '_validateInput'
@@ -349,6 +349,5 @@
       return isBlank;
     }
   }];
-
-
+})();
 </script>

--- a/px-polygit-imports-datetime.html
+++ b/px-polygit-imports-datetime.html
@@ -1,3 +1,9 @@
+<!--
+  THIS FILE IS INCLUDED FOR DEMONSTRATION PURPOSES ONLY AND IS NOT MEANT TO BE
+  LOADED BY PRODUCTION APPLICATIONS. THIS FILE IS USED TO LOAD THE MOMENT
+  LIBRARY FROM CDN FOR CODEPEN EXAMPLES. DO NOT LOAD THIS IN YOUR APP.
+-->
+
 <script src="https://cdn.rawgit.com/moment/moment/2.13.0/min/moment.min.js"></script>
 <script src="https://cdn.rawgit.com/moment/moment-timezone/0.5.5/builds/moment-timezone-with-data.min.js"></script>
 


### PR DESCRIPTION
* Moves all behaviors to explicitly use the PxDatetimeBehavior namespace
* Ensures that all behaviors are declared in a way that will attach them to the window even if executed in an IIFE or other non-global-level way when loaded by customer applications
* Small code cleanup

This change is required because some customers are bundling our components in their build process and placing each one's script tag into an IIFE. We were relying on the script tags being executed in the global scope so `var behaviorName` would automatically be set as `window.behaviorName` at the same time. This wasn't a strong contract, and there was no reason for us not to explicitly attach behaviors to the window so they work in any place.

Also took the opportunity to clean up naming, spacing/style, etc.

This will be a breaking change and should be a major version bump. That's OK though because as far as we know, we're the only consumers of the px-datetime-common component. Our datetime components use these behaviors. Once this PR is approved, I'll merge/tag this repo with a new major version then update all the datetime components to use the new version and tag those as patches.

cc @katemenkhaus @mdwragg @benoitjchevalier for your review.